### PR TITLE
Removes requirement to have '.git' suffix in HTTPS origin.

### DIFF
--- a/src/main/groovy/nebula/plugin/netflixossproject/publishing/PublishingPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/netflixossproject/publishing/PublishingPlugin.groovy
@@ -90,7 +90,7 @@ class PublishingPlugin implements Plugin<Project> {
         }
     }
 
-    static GIT_PATTERN = /((git|ssh|https?):(\/\/))?(\w+@)?([\w\.]+)([\:\\/])([\w\.@\:\/\-~]+)(\.git)(\/)?/
+    static GIT_PATTERN = /((git|ssh|https?):(\/\/))?(\w+@)?([\w\.]+)([\:\\/])([\w\.@\:\/\-~]+)(\/)?/
 
     /**
      * Convert git syntax of git@github.com:reactivex/rxjava-core.git to https://github.com/reactivex/rxjava-core
@@ -98,12 +98,12 @@ class PublishingPlugin implements Plugin<Project> {
      */
     static String calculateUrlFromOrigin(String origin) {
         def m = origin =~ GIT_PATTERN
-        return "https://${m[0][5]}/${m[0][7]}"
+        return "https://${m[0][5]}/" + (m[0][7] - '.git')
     }
 
     static String calculateRepoFromOrigin(String origin) {
         def m = origin =~ GIT_PATTERN
-        String path = m[0][7]
+        String path = m[0][7] - '.git'
         path.tokenize('/').last()
     }
 }

--- a/src/test/groovy/nebula/plugin/netflixossproject/publishing/PublishingPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/netflixossproject/publishing/PublishingPluginSpec.groovy
@@ -16,13 +16,45 @@
 package nebula.plugin.netflixossproject.publishing
 
 import nebula.test.ProjectSpec
+import spock.lang.Unroll
 
 class PublishingPluginSpec extends ProjectSpec {
-    def 'applying does not throw exceptions'() {
-        when:
-        project.plugins.apply PublishingPlugin
+  def 'applying does not throw exceptions'() {
+    when:
+    project.plugins.apply PublishingPlugin
 
-        then:
-        noExceptionThrown()
-    }
+    then:
+    noExceptionThrown()
+  }
+
+  @Unroll
+  void 'should get URL from origin'() {
+    when:
+    def result = PublishingPlugin.calculateUrlFromOrigin(input)
+
+    then:
+    result == output
+
+    where:
+    input                                          || output
+    'git@github.com:reactivex/rxjava-core.git'     || 'https://github.com/reactivex/rxjava-core'
+    'https://github.com/reactivex/rxjava-core'     || 'https://github.com/reactivex/rxjava-core'
+    'https://github.com/reactivex/rxjava-core.git' || 'https://github.com/reactivex/rxjava-core'
+  }
+
+  @Unroll
+  void 'should get Repo from origin'() {
+    when:
+    def result = PublishingPlugin.calculateRepoFromOrigin(input)
+
+    then:
+    result == output
+
+    where:
+    input                                          || output
+    'git@github.com:reactivex/rxjava-core.git'     || 'rxjava-core'
+    'https://github.com/reactivex/rxjava-core'     || 'rxjava-core'
+    'https://github.com/reactivex/rxjava-core.git' || 'rxjava-core'
+
+  }
 }


### PR DESCRIPTION
We've had many users bump up against this bug, and now it's blocking our ability to use build triggers.

FYI @cfieber @duftler @skim1420

Fixes https://github.com/nebula-plugins/gradle-netflixoss-project-plugin/issues/22