### PR TITLE
Apply defaultVersionStrategy only if Release Plugin Found

### DIFF
--- a/src/main/groovy/nebula/plugin/netflixossproject/NetflixOssProjectPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/netflixossproject/NetflixOssProjectPlugin.groovy
@@ -53,7 +53,7 @@ class NetflixOssProjectPlugin implements Plugin<Project> {
             project.plugins.apply ReleasePlugin
             if (type.isRootProject) {
                 ReleasePluginExtension releaseExtension = project.extensions.findByType(ReleasePluginExtension)
-                releaseExtension.with {
+                releaseExtension?.with {
                     defaultVersionStrategy = NetflixOssStrategies.SNAPSHOT
                 }
             }


### PR DESCRIPTION
This change allows the nebula.release plugin's error messaging to be logged (and continue without the release tasks) instead of throwing a NPE that stops the build. See netflix/ndbench#39.