### PR TITLE
Cleanup publishing: remove artifactory plugin related configuration and make sure we can not use immutableSnapshot

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,6 @@ dependencies {
     implementation("com.netflix.nebula:nebula-release-plugin:latest.release")
     implementation("com.netflix.nebula:gradle-java-cross-compile-plugin:latest.release")
     implementation("gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0")
-    implementation("org.jfrog.buildinfo:build-info-extractor-gradle:latest.release")
     testImplementation("org.ajoberstar.grgit:grgit-core:3.1.1") {
         exclude(group = "org.codehaus.groovy", module = "groovy")
     }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -5,11 +5,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -25,15 +25,15 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
@@ -47,10 +47,6 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.3.61",
             "requested": "1.3.61"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "compileOnlyDependenciesMetadata": {
@@ -69,11 +65,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -89,24 +85,20 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
             "locked": "0.14.0",
             "requested": "0.14.0"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "embeddedKotlin": {
@@ -125,11 +117,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -145,24 +137,20 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
             "locked": "0.14.0",
             "requested": "0.14.0"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "integTestCompileClasspath": {
@@ -171,11 +159,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -191,19 +179,19 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.6.0",
+            "locked": "7.8.5",
             "requested": "7.+"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
@@ -221,10 +209,6 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.3.61",
             "requested": "1.3.61"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "integTestRuntimeClasspath": {
@@ -233,11 +217,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -253,19 +237,19 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.6.0",
+            "locked": "7.8.5",
             "requested": "7.+"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
@@ -283,10 +267,6 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.3.61",
             "requested": "1.3.61"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "jacocoAgent": {
@@ -320,11 +300,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -340,24 +320,20 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
             "locked": "0.14.0",
             "requested": "0.14.0"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "testCompileClasspath": {
@@ -366,11 +342,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -386,19 +362,19 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.6.0",
+            "locked": "7.8.5",
             "requested": "7.+"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
@@ -416,10 +392,6 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.3.61",
             "requested": "1.3.61"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -428,11 +400,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -448,19 +420,19 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.6.0",
+            "locked": "7.8.5",
             "requested": "7.+"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
@@ -478,10 +450,6 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.3.61",
             "requested": "1.3.61"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     },
     "testRuntimeClasspath": {
@@ -490,11 +458,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-dependency-lock-plugin": {
-            "locked": "8.7.2",
+            "locked": "8.8.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-info-plugin": {
-            "locked": "5.2.0",
+            "locked": "7.1.3",
             "requested": "latest.release"
         },
         "com.netflix.nebula:gradle-java-cross-compile-plugin": {
@@ -510,19 +478,19 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "7.0.5",
+            "locked": "7.0.7",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-publishing-plugin": {
-            "locked": "14.1.1",
+            "locked": "17.2.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-release-plugin": {
-            "locked": "14.0.2",
+            "locked": "14.1.0",
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.6.0",
+            "locked": "7.8.5",
             "requested": "7.+"
         },
         "gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin": {
@@ -540,10 +508,6 @@
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
             "locked": "1.3.61",
             "requested": "1.3.61"
-        },
-        "org.jfrog.buildinfo:build-info-extractor-gradle": {
-            "locked": "4.13.0",
-            "requested": "latest.release"
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/netflixossproject/NetflixOssProjectPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/netflixossproject/NetflixOssProjectPlugin.groovy
@@ -68,8 +68,8 @@ class NetflixOssProjectPlugin implements Plugin<Project> {
 
         if (type.isRootProject) {
             project.gradle.taskGraph.whenReady { TaskExecutionGraph graph ->
-                if (graph.hasTask(':devSnapshot')) {
-                    throw new GradleException('You cannot use the devSnapshot task from the release plugin. Please use the snapshot task.')
+                if (graph.hasTask(':devSnapshot') || graph.hasTask(':immutableSnapshot')) {
+                    throw new GradleException('You cannot use the devSnapshot or immutableSnapshot task from the release plugin. Please use the snapshot task.')
                 }
 
             }

--- a/src/main/groovy/nebula/plugin/netflixossproject/publishing/PublishingPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/netflixossproject/publishing/PublishingPlugin.groovy
@@ -30,8 +30,6 @@ import org.gradle.api.Task
 import org.gradle.api.execution.TaskExecutionGraph
 import org.gradle.api.publish.tasks.GenerateModuleMetadata
 import org.gradle.api.tasks.Upload
-import org.jfrog.gradle.plugin.artifactory.task.ArtifactoryTask
-import org.jfrog.gradle.plugin.artifactory.task.DeployTask
 
 class PublishingPlugin implements Plugin<Project> {
 
@@ -62,15 +60,6 @@ class PublishingPlugin implements Plugin<Project> {
         project.tasks.withType(NebulaBintrayVersionTask, disable)
         project.tasks.withType(NebulaBintrayVersionTask, runOnlyForCandidateAndFinal)
         project.tasks.withType(Upload, disable)
-        def runOnlyForSnapshots = { Task task ->
-            project.gradle.taskGraph.whenReady { TaskExecutionGraph graph ->
-                task.onlyIf {
-                    graph.hasTask(':snapshot') || graph.hasTask(':devSnapshot')
-                }
-            }
-        }
-        project.tasks.withType(ArtifactoryTask, runOnlyForSnapshots)
-        project.tasks.withType(DeployTask, runOnlyForSnapshots)
 
         BintrayExtension bintray = project.rootProject == project ? project.extensions.getByType(BintrayExtension) : project.rootProject.extensions.getByType(BintrayExtension)
         bintray.with {

--- a/src/test/groovy/nebula/plugin/netflixossproject/NetflixOssProjectIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/netflixossproject/NetflixOssProjectIntegrationSpec.groovy
@@ -18,7 +18,9 @@ package nebula.plugin.netflixossproject
 import nebula.plugin.responsible.NebulaIntegTestPlugin
 import nebula.test.IntegrationSpec
 import org.ajoberstar.grgit.Grgit
+import org.gradle.api.GradleException
 import org.gradle.api.plugins.JavaPlugin
+import spock.lang.Unroll
 
 class NetflixOssProjectIntegrationSpec extends IntegrationSpec {
     Grgit grgit;
@@ -50,6 +52,18 @@ class NetflixOssProjectIntegrationSpec extends IntegrationSpec {
 
         then:
         noExceptionThrown()
+    }
+
+    @Unroll
+    def 'build should break when #task from release plugin is used'() {
+        when:
+        def result = runTasksWithFailure(task)
+
+        then:
+        result.standardError.contains('You cannot use the devSnapshot or immutableSnapshot task from the release plugin. Please use the snapshot task')
+
+        where:
+        task << ['devSnapshot', 'immutableSnapshot']
     }
 
     def 'verify manifest created' () {


### PR DESCRIPTION
This PR is to remove old code to support artifactory plugin. We now rely on Gradle's publishing mechanism

Also, builds will fail when `immutableSnapshot` is invoked.

The reason for that is that we configure different URLs for snapshots vs candidate/final: https://github.com/nebula-plugins/nebula-bintray-plugin/blob/master/src/main/kotlin/nebula/plugin/bintray/NebulaBintrayPublishingPlugin.kt#L185

This is because the nature of the [Bintray API](https://bintray.com/docs/api/) for non snapshot things

When using OSS artifactory repo, it uses maven mechanism for snapshots where each <version>-SNAPSHOT contains a maven-metadata.xml file, for example: https://oss.jfrog.org/artifactory/oss-snapshot-local/com/netflix/spectator/spectator-ext-jvm/0.103.0-SNAPSHOT/

While the version is mutable, the artifacts are stored in case someone wants to use them later.

If we wanted to push `devSnapshot` or `immutableSnapshot` we would need to create our own snapshots repo under `netflixoss` account and then configure it accordingly to use Bintray's API. 

Let's chat if we want to do that and if there is value out of it, but in the mean time, we should probably fail the build 